### PR TITLE
(SIMP-4696) Re-namespace voxpupuli/selinux

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,5 +3,5 @@ fixtures:
     concat: https://github.com/puppetlabs/puppetlabs-concat.git
     stdlib: https://github.com/puppetlabs/puppetlabs-stdlib.git
   symlinks:
-    selinux: "#{source_dir}"
+    vox_selinux: "#{source_dir}"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,46 +1,86 @@
+# The testing matrix considers ruby/puppet versions supported by SIMP and PE:
+# ------------------------------------------------------------------------------
+#  release    pup   ruby      eol
+# PE 2016.4   4.7   2.1.9  TBD (LTS)
+# PE 2016.5   4.8   2.1.9  2017-10-31
+# SIMP6.0.0   4.8   2.1.9  TBD
+# PE 2017.1   4.9   2.1.9  2017-10-31
+# PE 2017.2   4.10  2.1.9  TBD
 ---
-sudo: false
-dist: trusty
 language: ruby
 cache: bundler
-before_install:
-  - rm -f Gemfile.lock
-script:
-  - 'bundle exec rake $CHECK'
-matrix:
-  fast_finish: true
-  include:
-  - rvm: 2.1.9
-    bundler_args: --without system_tests development release
-    env: PUPPET_VERSION="~> 4.0" CHECK=test PARALLEL_TEST_PROCESSORS=16
-  - rvm: 2.4.2
-    bundler_args: --without system_tests development release
-    env: PUPPET_VERSION="~> 5.0" CHECK=test_with_coveralls
-  - rvm: 2.4.2
-    bundler_args: --without system_tests development release
-    env: PUPPET_VERSION="~> 5.0" CHECK=rubocop
-  - rvm: 2.4.2
-    bundler_args: --without system_tests development release
-    env: PUPPET_VERSION="~> 5.0" CHECK=build DEPLOY_TO_FORGE=yes
-branches:
-  only:
-  - master
-  - /^v\d/
+sudo: false
+
+bundler_args: --without development system_tests --path .vendor
+
 notifications:
   email: false
-  irc:
-    on_success: always
-    on_failure: always
-    channels:
-      - "chat.freenode.org#voxpupuli-notifications"
-deploy:
-  provider: puppetforge
-  user: puppet
-  password:
-    secure: "r7NI3OHbyMs/w351LkmkTFFLriDDyWKvgyZt+XYPw7jbaWmqnV4+NSJMQSkXgTS+tq2jNPLOWY1UuPuFJKkyd1m7LteOb2yZ6HJs5BL7QJjJWC2vUjkY60kl2xHn81D6SEXOXoVseGWiimlTlWJM3pKljNgZOZlOMw96vgnd6/I="
-  on:
-    tags: true
-    # all_branches is required to use tags
-    all_branches: true
-    # Only publish the build marked with "DEPLOY_TO_FORGE"
-    condition: "$DEPLOY_TO_FORGE = yes"
+
+addons:
+  apt:
+    packages:
+      - rpm
+
+before_install:
+  - rm -f Gemfile.lock
+
+jobs:
+  allow_failures:
+    - env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
+
+  include:
+    - stage: check
+      rvm: 2.4.1
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5"
+      script:
+        - bundle exec rake metadata_lint
+        - bundle exec puppet module build
+
+    - stage: spec
+      rvm: 2.4.1
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.10.0"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.9.2"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.7.0"
+      script:
+        - bundle exec rake spec
+
+    # This needs to be last since we have an acceptance test
+    - stage: deploy
+      rvm: 2.4.1
+      script:
+        - true
+      before_deploy:
+        - "export PUPMOD_METADATA_VERSION=`ruby -r json -e \"puts JSON.parse(File.read('metadata.json')).fetch('version')\"`"
+        - '[[ $TRAVIS_TAG =~ ^simp-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
+      deploy:
+        - provider: releases
+          api_key:
+            secure: "zaXAJvMReNdmp7+t2liAlZ6wxCCTvj2AmhLnn/XMKAAVXmnbfeH57OjnQeO3XFCeMgjYYL+WGjosc3e0Zgifm1mMRNwnp/J2AzCXhaKnQZCPdiPnx2XpdEC0fIW4RBI3TTnKqL8qjlqOZgt/EHBBwdfIfSGhf/wh4+OBY2gDjqInTGGSLKl32J/mVml5Sy6ZM8J4Qa3qvr7hlnbVJpmSYBcoy0yv2bWlwCVPv8/VWaU0I7z5DY038FTOnd+E/5Z+3j2bvqJ0UhaMyD48uTe+FpdfRmzeOYmPzETcYiNil8zOw++mBzU8GPZaFdZnT69krMBeGd98tLLCvvoUw46uXH3TUg89JRSt5YHZ1M5rskQukn2PLWhFEss0sKAyt61wRjWDSfqjXmi6AUdsULyhgm6a1ImjsAl/SNPUm0rqmQBL5CYvQeEIV4OJOszpt+/hzhFA56+rpcQTsRYNvMlPcg6itQ19jk3f1XL0ld+xuuAmCMAFqM+FQKeyIwiMivGzVYcOwbZzOF/wDmrX6QUeEPq2BvK7pVy7N529nDN+lCGliGO0oWGkuRU2X58urlmtnwchyNLnpLHPNJkF6356G+M7rWFU62hYL84lmLrD0qAM13moB9TPO637h1GToU1bFQ5i/Pa1yc2hpzoYxbXmcKFYn20JLui06Uxae7jr5dg="
+          skip_cleanup: true
+          on:
+            tags: true
+            condition: '($SKIP_FORGE_PUBLISH != true)'
+        - provider: puppetforge
+          user: simp
+          password:
+            secure: "rpiX9RQV0K20xG8pPC5uTAgn4mfdYCBA3mqw0lfi9Gu9i10Hjdl4RlV7Ja1nDwanKK2RerFC/TwrjQTHIrwDztkqGuq0yKn9E+TmbYe+e70Pu4QMHS8qHkzyyVBM9woOeM4n68evZ0mYeG42FzggPuAKo6RgYPISz/69YnVVqE4klB+YKut5M9dEBzuhIMzXIjpBnrh3lWL/kZy7CdsK1M2CzhuSRARJnQ/i9Pay4srBUueFy6+1QSyHdwKvKKYMroGHNR3ZhKdlMzh1aNKk268ek0GHw8gvxtU1sfGYawNZDTRfRRIFRzrb58i6Am6mvAKyIS5Zu7O2Myduj27ZbYX90y1Ki4s6nC8LIy6IjOjQSQHlY1BS9dGzFpa+oeg52gpJctEo0cC282n55YNUHi04xdhikPXGzAn+r2wQK6kxc36F7B1hGS29CX2T1vJw4WQ6DXhcrII+SdskJZcgZQGIdbEENd3X2ZVgnfLKE5tzwkgoMYGhKSFjGby9IfAbq/jXN3HIoZPZjleVHw6+2SyDdQIWQzBQSIDSK2xyDxeipczJo3uOpLnoxREGgYyyagVhkloCGsovspnzS4Kyiqo+aJ8cwDS9hsKzcTiZdjfxoU5SrWg56Y6dn7JDE17mIESOkOhJHTVsATxXtvApEtLAFeUYuQx+HgLA2c6lGEA="
+          on:
+            tags: true
+            rvm: 2.4.1
+            condition: '($SKIP_FORGE_PUBLISH != true)'

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # SELinux module for Puppet
 
-[![Build Status](https://travis-ci.org/voxpupuli/puppet-selinux.png?branch=master)](https://travis-ci.org/voxpupuli/puppet-selinux)
-[![Code Coverage](https://coveralls.io/repos/github/voxpupuli/puppet-selinux/badge.svg?branch=master)](https://coveralls.io/github/voxpupuli/puppet-selinux)
-[![Puppet Forge](https://img.shields.io/puppetforge/v/puppet/selinux.svg)](https://forge.puppetlabs.com/puppet/selinux)
-[![Puppet Forge - downloads](https://img.shields.io/puppetforge/dt/puppet/selinux.svg)](https://forge.puppetlabs.com/puppet/selinux)
-[![Puppet Forge - endorsement](https://img.shields.io/puppetforge/e/puppet/selinux.svg)](https://forge.puppetlabs.com/puppet/selinux)
-[![Puppet Forge - scores](https://img.shields.io/puppetforge/f/puppet/selinux.svg)](https://forge.puppetlabs.com/puppet/selinux)
+[![Build Status](https://travis-ci.org/simp/pupmod-voxpupuli-selinux.png?branch=master)](https://travis-ci.org/simp/pupmod-voxpupuli-selinux)
+[![Puppet Forge](https://img.shields.io/puppetforge/v/simp/vox_selinux.svg)](https://forge.puppetlabs.com/simp/vox_selinux)
+[![Puppet Forge - downloads](https://img.shields.io/puppetforge/dt/simp/vox_selinux.svg)](https://forge.puppetlabs.com/simp/vox_selinux)
+[![Puppet Forge - endorsement](https://img.shields.io/puppetforge/e/simp/vox_selinux.svg)](https://forge.puppetlabs.com/simp/vox_selinux)
+[![Puppet Forge - scores](https://img.shields.io/puppetforge/f/simp/vox_selinux.svg)](https://forge.puppetlabs.com/simp/vox_selinux)
 
 #### Table of Contents
 
@@ -21,6 +20,31 @@
 
 This class manages SELinux on RHEL based systems.
 
+---
+
+> This module has been forked from
+> (voxpupuli/selinux)[https://github.com/voxpupuli/puppet-selinux] so that it
+> could be re-namespaced as `vox_selinux` for the
+> (SIMP)[https://simp-project.com] framework.
+>
+> Migration to the upstream module will happen in the future after sufficient
+> time has been provided for users to migrate away from the legacy SIMP
+> provided module.
+>
+> Any changes made here should be sent in as PRs to the upstream module and
+> this should not deviate from the upstream release outside of the namespace if
+> at all possible.
+>
+> Per the Apache 2.0 license requirements, the following changes have been made:
+> * Renamed the module from `puppet/selinux` to `simp/vox_selinux`
+> * Changed the namespace for all components to `vox_selinux`
+> * Updated the tests to reflect the changes
+> * Disabled reporting to the `voxpupuli` channels on test failures
+> * Updated .travis.yml for deployment and SIMP-style testing stages
+> * Updated the README.md to note the changes
+
+---
+
 ## Requirements
 
 * Puppet 4 or later
@@ -29,13 +53,6 @@ This class manages SELinux on RHEL based systems.
 
 This module will configure SELinux and/or deploy SELinux based modules to
 running system.
-
-## Get in touch
-
-* IRC: [#voxpupuli on irc.freenode.net](irc://irc.freenode.net/voxpupuli)
-  ([Freenode WebChat](http://webchat.freenode.net/?channels=%23voxpupuli))
-* Mailinglist: <voxpupuli@groups.io>
-  ([groups.io Webinterface](https://groups.io/g/voxpupuli/topics))
 
 ## Upgrading from puppet-selinux 0.8.x
 
@@ -63,17 +80,17 @@ running system.
   will downgrade to permissive mode instead to avoid transitioning directly from
   disabled to enforcing state after a reboot and potentially breaking the system.
   The user will receive a warning when this happens,
-* If you add filecontexts with `semanage fcontext` (what `selinux::fcontext`
+* If you add filecontexts with `semanage fcontext` (what `vox_selinux::fcontext`
   does) the order is important. If you add /my/folder before /my/folder/subfolder
   only /my/folder will match (limitation of SELinux). There is no such limitation
   to file-contexts defined in SELinux modules. (GH-121)
-* While SELinux is disabled the defined types `selinux::boolean`,
-  `selinux::fcontext`, `selinux::port` will produce puppet agent runtime errors
+* While SELinux is disabled the defined types `vox_selinux::boolean`,
+  `vox_selinux::fcontext`, `vox_selinux::port` will produce puppet agent runtime errors
   because the used tools fail.
 * If you try to remove a built-in permissive type, the operation will appear to succeed
   but will actually have no effect, making your puppet runs non-idempotent.
-* The `selinux_port` provider may misbehave if the title does not correspond to
-  the format it expects. Users should use the `selinux::port` define instead except
+* The `vox_selinux_port` provider may misbehave if the title does not correspond to
+  the format it expects. Users should use the `vox_selinux::port` define instead except
   when purging resources
 * Defining port ranges that overlap with existing ranges is currently not detected, and will
   cause semanage to error when the resource is applied.
@@ -81,7 +98,7 @@ running system.
 ## Usage
 
 Generated puppet strings documentation with examples is available from
-https://voxpupuli.org/puppet-selinux/
+https://github.com/simp/pupmod-voxpupuli-selinux
 
 It's also included in the docs/ folder as simple html pages.
 
@@ -90,7 +107,7 @@ It's also included in the docs/ folder as simple html pages.
 ### Basic usage
 
 ```puppet
-include selinux
+include vox_selinux
 ```
 
 This will include the module and allow you to use the provided defined types,
@@ -99,7 +116,7 @@ but will not modify existing SELinux settings on the system.
 ### More advanced usage
 
 ```puppet
-class { selinux:
+class { vox_selinux:
   mode => 'enforcing',
   type => 'targeted',
 }
@@ -114,7 +131,7 @@ to fully take effect. It will run in `permissive` mode until then.
 ### Deploy a custom module using the refpolicy framework
 
 ```puppet
-selinux::module { 'resnet-puppet':
+vox_selinux::module { 'resnet-puppet':
   ensure    => 'present',
   source_te => 'puppet:///modules/site_puppet/site-puppet.te',
   source_fc => 'puppet:///modules/site_puppet/site-puppet.fc',
@@ -126,7 +143,7 @@ selinux::module { 'resnet-puppet':
 ### Set a boolean value
 
 ```puppet
-selinux::boolean { 'puppetagent_manage_all_files': }
+vox_selinux::boolean { 'puppetagent_manage_all_files': }
 ```
 
 ## Defined Types

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,14 +1,14 @@
 ---
 lookup_options:
-  selinux::boolean:
+  vox_selinux::boolean:
     merge: hash
-  selinux::fcontext:
+  vox_selinux::fcontext:
     merge: hash
-  selinux::module:
+  vox_selinux::module:
     merge: hash
-  selinux::permissive:
+  vox_selinux::permissive:
     merge: hash
-  selinux::port:
+  vox_selinux::port:
     merge: hash
-  selinux::exec_restorecon:
+  vox_selinux::exec_restorecon:
     merge: hash

--- a/manifests/boolean.pp
+++ b/manifests/boolean.pp
@@ -1,30 +1,30 @@
-# selinux::boolean
+# vox_selinux::boolean
 #
 # This class will set the state of an SELinux boolean.
 #
 # @example Enable `named_write_master_zones`  boolean
-#   selinux::boolean{ 'named_write_master_zones':
+#   vox_selinux::boolean{ 'named_write_master_zones':
 #      ensure     => 'on',
 #   }
 #
 # @example Ensure `named_write_master_zones` boolean is disabled
-#   selinux::boolean{ 'named_write_master_zones':
+#   vox_selinux::boolean{ 'named_write_master_zones':
 #      ensure     => 'off',
 #   }
 #
 # @param ensure Set to on or off
 # @param persistent Set to false if you don't want it to survive a reboot.
 #
-define selinux::boolean (
+define vox_selinux::boolean (
   Variant[Boolean, Enum['on', 'off', 'present', 'absent']] $ensure = 'on',
   Boolean $persistent = true,
 ) {
 
-  include ::selinux
+  include ::vox_selinux
 
-  Anchor['selinux::module post']
-  -> Selinux::Boolean[$title]
-  -> Anchor['selinux::end']
+  Anchor['vox_selinux::module post']
+  -> Vox_selinux::Boolean[$title]
+  -> Anchor['vox_selinux::end']
 
   $ensure_real = $ensure ? {
     true    => 'on',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,11 +1,11 @@
-# Class: selinux::config
+# Class: vox_selinux::config
 #
 # THIS IS A PRIVATE CLASS
 # =======================
 #
 # This class is designed to configure the system to use SELinux on the system.
 #
-# It is included in the main class ::selinux
+# It is included in the main class ::vox_selinux
 #
 #
 #
@@ -27,12 +27,12 @@
 # @param package_name See main class
 # @param module_build_root See main class
 #
-class selinux::config (
-  $mode                                   = $::selinux::mode,
-  $type                                   = $::selinux::type,
-  $manage_package                         = $::selinux::manage_package,
-  $package_name                           = $::selinux::package_name,
-  Stdlib::Absolutepath $module_build_root = $::selinux::module_build_root
+class vox_selinux::config (
+  $mode                                   = $::vox_selinux::mode,
+  $type                                   = $::vox_selinux::type,
+  $manage_package                         = $::vox_selinux::manage_package,
+  $package_name                           = $::vox_selinux::package_name,
+  Stdlib::Absolutepath $module_build_root = $::vox_selinux::module_build_root
 ) {
 
   if $caller_module_name != $module_name {
@@ -40,7 +40,7 @@ class selinux::config (
   }
 
   if ($mode == 'enforcing' and !$::selinux) {
-    notice('SELinux is disabled. Forcing configuration to permissive to avoid problems. To disable this warning, explicitly set selinux::mode to permissive or disabled.')
+    notice('SELinux is disabled. Forcing configuration to permissive to avoid problems. To disable this warning, explicitly set vox_selinux::mode to permissive or disabled.')
     $_real_mode = 'permissive'
   } else {
     $_real_mode = $mode

--- a/manifests/exec_restorecon.pp
+++ b/manifests/exec_restorecon.pp
@@ -1,9 +1,9 @@
-# selinux::exec_restorecon
+# vox_selinux::exec_restorecon
 #
 # A convenience wrapper around a restorecon exec
 #
 # Will execute after all other SELinux changes have been applied, but before
-# Anchor['selinux::end']
+# Anchor['vox_selinux::end']
 #
 # @param path The path to run restorecon on. Defaults to resource title.
 # @param recurse Whether restorecon should recurse. Defaults to true
@@ -12,7 +12,7 @@
 # @param unless see the Exec resource
 # @param onlyif see the Exec resource
 #
-define selinux::exec_restorecon(
+define vox_selinux::exec_restorecon(
   Stdlib::Absolutepath $path        = $title,
   Boolean              $refreshonly = true,
   Boolean              $recurse     = true,
@@ -21,7 +21,7 @@ define selinux::exec_restorecon(
   Optional[String]     $onlyif      = undef,
 ) {
 
-  include ::selinux
+  include ::vox_selinux
 
   $opt_recurse = $recurse ? {
     true  => ' -R',
@@ -35,14 +35,14 @@ define selinux::exec_restorecon(
 
   $command = "restorecon${opt_force}${opt_recurse}"
 
-  exec {"selinux::exec_restorecon ${path}":
+  exec {"vox_selinux::exec_restorecon ${path}":
     path        => '/sbin:/usr/sbin',
     command     => sprintf('%s %s', $command, shellquote($path)),
     refreshonly => $refreshonly,
     unless      => $unless,
     onlyif      => $onlyif,
-    before      => Anchor['selinux::end'],
+    before      => Anchor['vox_selinux::end'],
   }
 
-  Anchor['selinux::module post']  -> Exec["selinux::exec_restorecon ${path}"]
+  Anchor['vox_selinux::module post']  -> Exec["vox_selinux::exec_restorecon ${path}"]
 }

--- a/manifests/fcontext.pp
+++ b/manifests/fcontext.pp
@@ -1,16 +1,16 @@
-# selinux::fcontext
+# vox_selinux::fcontext
 #
 # This define can be used to manage custom SELinux fcontexts. For fcontext 
-# equivalences, see selinux::fcontext::equivalence
+# equivalences, see vox_selinux::fcontext::equivalence
 #
 # @example Add a file-context for mysql log files at non standard location
-#   selinux::fcontext{'set-mysql-log-context':
+#   vox_selinux::fcontext{'set-mysql-log-context':
 #     seltype => "mysqld_log_t",
 #     pathspec => "/u01/log/mysql(/.*)?",
 #   }
 #
 # @example Add a file-context only for directory types 
-#   selinux::fcontext{'/u/users/[^/]*':
+#   vox_selinux::fcontext{'/u/users/[^/]*':
 #     filetype => 'd',
 #     seltype  => 'user_home_dir_t' ,
 #   }
@@ -30,7 +30,7 @@
 #       - s = socket
 #       - l = symbolic link
 #       - p = named pipe
-define selinux::fcontext(
+define vox_selinux::fcontext(
   String $pathspec                  = $title,
   Enum['absent', 'present'] $ensure = 'present',
   Optional[String] $seltype         = undef,
@@ -38,15 +38,15 @@ define selinux::fcontext(
   Optional[String] $filetype        = 'a',
 ) {
 
-  include ::selinux
+  include ::vox_selinux
   if $ensure == 'present' {
-  Anchor['selinux::module post']
-  -> Selinux::Fcontext[$title]
-  -> Anchor['selinux::end']
+  Anchor['vox_selinux::module post']
+  -> Vox_selinux::Fcontext[$title]
+  -> Anchor['vox_selinux::end']
   } else {
-    Anchor['selinux::start']
-    -> Selinux::Fcontext[$title]
-    -> Anchor['selinux::module pre']
+    Anchor['vox_selinux::start']
+    -> Vox_selinux::Fcontext[$title]
+    -> Anchor['vox_selinux::module pre']
   }
 
   if $filetype !~ /^(?:a|f|d|c|b|s|l|p)$/ {

--- a/manifests/fcontext/equivalence.pp
+++ b/manifests/fcontext/equivalence.pp
@@ -1,4 +1,4 @@
-# selinux::fcontext::equivalence
+# vox_selinux::fcontext::equivalence
 #
 # This define can be used to manage SELinux fcontext equivalences
 #
@@ -7,27 +7,27 @@
 # @param ensure the desired state of the equivalence. Default: present
 #
 # @example Make /opt/wordpress equivalent to /usr/share/wordpress
-#   selinux::fcontext::equivalence { '/opt/wordpress':
+#   vox_selinux::fcontext::equivalence { '/opt/wordpress':
 #     ensure => 'present',
 #     target => '/usr/share/wordpress',
 #   }
 #
-define selinux::fcontext::equivalence(
+define vox_selinux::fcontext::equivalence(
   String $target,
   String $path = $title,
   Enum['present', 'absent'] $ensure = 'present'
 ) {
 
-  include ::selinux
+  include ::vox_selinux
 
   if $ensure == 'present' {
-    Anchor['selinux::module post']
-    -> Selinux::Fcontext::Equivalence[$title]
-    -> Anchor['selinux::end']
+    Anchor['vox_selinux::module post']
+    -> Vox_selinux::Fcontext::Equivalence[$title]
+    -> Anchor['vox_selinux::end']
   } else {
-    Anchor['selinux::start']
-    -> Selinux::Fcontext::Equivalence[$title]
-    -> Anchor['selinux::module pre']
+    Anchor['vox_selinux::start']
+    -> Vox_selinux::Fcontext::Equivalence[$title]
+    -> Anchor['vox_selinux::module pre']
   }
 
   selinux_fcontext_equivalence { $path:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,4 +1,4 @@
-# Class: selinux
+# Class: vox_selinux
 #
 # This class manages SELinux on RHEL based systems.
 #
@@ -25,23 +25,23 @@
 #   refpolicy module builder
 #   Default value: OS dependent (see params.pp)
 # @param module_build_root directory where modules are built. Defaults to `$vardir/puppet-selinux`
-# @param default_builder which builder to use by default with selinux::module
+# @param default_builder which builder to use by default with vox_selinux::module
 #   Default value: simple
-# @param boolean Hash of selinux::boolean resource parameters
-# @param fcontext Hash of selinux::fcontext resource parameters
-# @param module Hash of selinux::module resource parameters
-# @param permissive Hash of selinux::module resource parameters
-# @param port Hash of selinux::port resource parameters
-# @param exec_restorecon Hash of selinux::exec_restorecon resource parameters
+# @param boolean Hash of vox_selinux::boolean resource parameters
+# @param fcontext Hash of vox_selinux::fcontext resource parameters
+# @param module Hash of vox_selinux::module resource parameters
+# @param permissive Hash of vox_selinux::module resource parameters
+# @param port Hash of vox_selinux::port resource parameters
+# @param exec_restorecon Hash of vox_selinux::exec_restorecon resource parameters
 #
-class selinux (
-  Optional[Enum['enforcing', 'permissive', 'disabled']] $mode = $::selinux::params::mode,
-  Optional[Enum['targeted', 'minimum', 'mls']] $type          = $::selinux::params::type,
-  Stdlib::Absolutepath $refpolicy_makefile                    = $::selinux::params::refpolicy_makefile,
-  Boolean $manage_package                                     = $::selinux::params::manage_package,
-  String $package_name                                        = $::selinux::params::package_name,
-  String $refpolicy_package_name                              = $::selinux::params::refpolicy_package_name,
-  Stdlib::Absolutepath $module_build_root                     = $::selinux::params::module_build_root,
+class vox_selinux (
+  Optional[Enum['enforcing', 'permissive', 'disabled']] $mode = $::vox_selinux::params::mode,
+  Optional[Enum['targeted', 'minimum', 'mls']] $type          = $::vox_selinux::params::type,
+  Stdlib::Absolutepath $refpolicy_makefile                    = $::vox_selinux::params::refpolicy_makefile,
+  Boolean $manage_package                                     = $::vox_selinux::params::manage_package,
+  String $package_name                                        = $::vox_selinux::params::package_name,
+  String $refpolicy_package_name                              = $::vox_selinux::params::refpolicy_package_name,
+  Stdlib::Absolutepath $module_build_root                     = $::vox_selinux::params::module_build_root,
   Enum['refpolicy', 'simple'] $default_builder                = 'simple',
 
   ### START Hiera Lookups ###
@@ -53,39 +53,39 @@ class selinux (
   Optional[Hash] $exec_restorecon = undef,
   ### END Hiera Lookups ###
 
-) inherits selinux::params {
+) inherits vox_selinux::params {
 
-  class { '::selinux::package':
+  class { '::vox_selinux::package':
     manage_package => $manage_package,
     package_name   => $package_name,
   }
 
-  class { '::selinux::config': }
+  class { '::vox_selinux::config': }
 
   if $boolean {
-    create_resources ( 'selinux::boolean', $boolean )
+    create_resources ( 'vox_selinux::boolean', $boolean )
   }
   if $fcontext {
-    create_resources ( 'selinux::fcontext', $fcontext )
+    create_resources ( 'vox_selinux::fcontext', $fcontext )
   }
   if $module {
-    create_resources ( 'selinux::module', $module )
+    create_resources ( 'vox_selinux::module', $module )
   }
   if $permissive {
-    create_resources ( 'selinux::permissive', $permissive )
+    create_resources ( 'vox_selinux::permissive', $permissive )
   }
   if $port {
-    create_resources ( 'selinux::port', $port )
+    create_resources ( 'vox_selinux::port', $port )
   }
   if $exec_restorecon {
-    create_resources ( 'selinux::exec_restorecon', $exec_restorecon )
+    create_resources ( 'vox_selinux::exec_restorecon', $exec_restorecon )
   }
 
   # Ordering
-  anchor { 'selinux::start': }
-  -> Class['selinux::package']
-  -> Class['selinux::config']
-  -> anchor { 'selinux::module pre': }
-  -> anchor { 'selinux::module post': }
-  -> anchor { 'selinux::end': }
+  anchor { 'vox_selinux::start': }
+  -> Class['vox_selinux::package']
+  -> Class['vox_selinux::config']
+  -> anchor { 'vox_selinux::module pre': }
+  -> anchor { 'vox_selinux::module post': }
+  -> anchor { 'vox_selinux::end': }
 }

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -1,4 +1,4 @@
-# selinux::package
+# vox_selinux::package
 #
 # THIS IS A PRIVATE CLASS
 # =======================
@@ -8,9 +8,9 @@
 # @param manage_package See main class
 # @param package_name See main class
 #
-class selinux::package (
-  $manage_package = $::selinux::manage_package,
-  $package_name   = $::selinux::package_name,
+class vox_selinux::package (
+  $manage_package = $::vox_selinux::manage_package,
+  $package_name   = $::vox_selinux::package_name,
 ){
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,11 +1,11 @@
-# selinux::params
+# vox_selinux::params
 #
 # THIS IS A PRIVATE CLASS
 # =======================
 #
 # This class provides default parameters for the selinux class
 #
-class selinux::params {
+class vox_selinux::params {
   $refpolicy_makefile = '/usr/share/selinux/devel/Makefile'
   $mode           = undef
   $type           = undef

--- a/manifests/permissive.pp
+++ b/manifests/permissive.pp
@@ -1,4 +1,4 @@
-# selinux::permissive
+# vox_selinux::permissive
 #
 # This define will set an SELinux type to permissive
 #
@@ -6,24 +6,24 @@
 # @param seltype A particular selinux type to make permissive, like "oddjob_mkhomedir_t"
 #
 # @example Mark oddjob_mkhomedir_t permissive
-#   selinux::permissive { 'oddjob_mkhomedir_t':
+#   vox_selinux::permissive { 'oddjob_mkhomedir_t':
 #     ensure => 'present'
 #   }
 #
-define selinux::permissive (
+define vox_selinux::permissive (
   String $seltype = $title,
   Enum['present', 'absent'] $ensure = 'present',
 ) {
 
-  include ::selinux
+  include ::vox_selinux
   if $ensure == 'present' {
-    Anchor['selinux::module post']
-    -> Selinux::Permissive[$title]
-    -> Anchor['selinux::end']
+    Anchor['vox_selinux::module post']
+    -> Vox_selinux::Permissive[$title]
+    -> Anchor['vox_selinux::end']
   } else {
-    Anchor['selinux::start']
-    -> Selinux::Permissive[$title]
-    -> Anchor['selinux::module pre']
+    Anchor['vox_selinux::start']
+    -> Vox_selinux::Permissive[$title]
+    -> Anchor['vox_selinux::module pre']
   }
 
   selinux_permissive {$seltype:

--- a/manifests/port.pp
+++ b/manifests/port.pp
@@ -1,10 +1,10 @@
-# selinux::port
+# vox_selinux::port
 #
 # This method will manage a local network port context setting, and will
 # persist it across reboots.
 #
 # @example Add port-context syslogd_port_t to port 8514/tcp
-#   selinux::port { 'allow-syslog-relp':
+#   vox_selinux::port { 'allow-syslog-relp':
 #     ensure   => 'present',
 #     seltype  => 'syslogd_port_t',
 #     protocol => 'tcp',
@@ -17,7 +17,7 @@
 # @param port A network port number, like 8514,
 # @param port_range A port-range tuple, eg. [9090, 9095].
 #
-define selinux::port (
+define vox_selinux::port (
   String                             $seltype,
   Enum['tcp', 'udp']                 $protocol,
   Optional[Integer[1,65535]]         $port = undef,
@@ -25,16 +25,16 @@ define selinux::port (
   Enum['present', 'absent']          $ensure = 'present',
 ) {
 
-  include ::selinux
+  include ::vox_selinux
 
   if $ensure == 'present' {
-    Anchor['selinux::module post']
-    -> Selinux::Port[$title]
-    -> Anchor['selinux::end']
+    Anchor['vox_selinux::module post']
+    -> Vox_selinux::Port[$title]
+    -> Anchor['vox_selinux::end']
   } elsif $ensure == 'absent' {
-    Class['selinux::config']
-    -> Selinux::Port[$title]
-    -> Anchor['selinux::module pre']
+    Class['vox_selinux::config']
+    -> Vox_selinux::Port[$title]
+    -> Anchor['vox_selinux::module pre']
   } else {
     fail('Unexpected $ensure value')
   }

--- a/manifests/refpolicy_package.pp
+++ b/manifests/refpolicy_package.pp
@@ -1,4 +1,4 @@
-# selinux::package
+# vox_selinux::package
 #
 # THIS IS A PRIVATE CLASS
 # =======================
@@ -8,10 +8,10 @@
 # @param manage_package See main class
 # @param package_name See main class
 #
-class selinux::refpolicy_package (
-  $manage_package = $::selinux::manage_package,
-  $package_name   = $::selinux::refpolicy_package_name,
-) inherits ::selinux {
+class vox_selinux::refpolicy_package (
+  $manage_package = $::vox_selinux::manage_package,
+  $package_name   = $::vox_selinux::refpolicy_package_name,
+) inherits ::vox_selinux {
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")
   }

--- a/metadata.json
+++ b/metadata.json
@@ -1,15 +1,29 @@
 {
-  "name": "puppet-selinux",
+  "name": "simp-vox_selinux",
   "version": "1.5.2",
   "author": "Vox Pupuli",
-  "summary": "This class manages SELinux on RHEL based systems",
+  "summary": "This class manages SELinux on RHEL based systems - FORKED FROM puppet/selinux",
   "license": "Apache-2.0",
-  "source": "https://github.com/voxpupuli/puppet-selinux",
-  "project_page": "https://github.com/voxpupuli/puppet-selinux",
-  "issues_url": "https://github.com/voxpupuli/puppet-selinux/issues",
+  "source": "https://github.com/simp/pupmod-voxpupuli-selinux",
+  "project_page": "https://github.com/simp/pupmod-voxpupuli-selinux",
+  "issues_url": "https://simp-project.atlassian.net",
   "operatingsystem_support": [
     {
       "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
         "6",
         "7"

--- a/spec/classes/selinux_config_mode_spec.rb
+++ b/spec/classes/selinux_config_mode_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'selinux' do
+describe 'vox_selinux' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) do
@@ -16,7 +16,7 @@ describe 'selinux' do
         context 'invalid mode' do
           let(:params) { { mode: 'invalid' } }
 
-          it { expect { is_expected.to create_class('selinux') }.to raise_error(Puppet::Error, %r{Enum}) }
+          it { expect { is_expected.to create_class('vox_selinux') }.to raise_error(Puppet::Error, %r{Enum}) }
         end
 
         context 'undef mode' do

--- a/spec/classes/selinux_config_type_spec.rb
+++ b/spec/classes/selinux_config_type_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'selinux' do
+describe 'vox_selinux' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) do
@@ -11,7 +11,7 @@ describe 'selinux' do
         context 'invalid type' do
           let(:params) { { type: 'invalid' } }
 
-          it { expect { is_expected.to create_class('selinux') }.to raise_error(Puppet::Error, %r{Enum}) }
+          it { expect { is_expected.to create_class('vox_selinux') }.to raise_error(Puppet::Error, %r{Enum}) }
         end
         context 'undef type' do
           it { is_expected.to have_file_resource_count(5) }

--- a/spec/classes/selinux_package_spec.rb
+++ b/spec/classes/selinux_package_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'selinux' do
+describe 'vox_selinux' do
   context 'package' do
     %w[6 7].each do |majrelease|
       context "On RedHat #{majrelease} based OSes" do

--- a/spec/classes/selinux_spec.rb
+++ b/spec/classes/selinux_spec.rb
@@ -1,26 +1,26 @@
 require 'spec_helper'
 
-describe 'selinux' do
+describe 'vox_selinux' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) do
         facts
       end
 
-      it { is_expected.to contain_class('selinux').without_mode }
-      it { is_expected.to contain_class('selinux').without_type }
-      it { is_expected.to contain_class('selinux').without_module }
-      it { is_expected.to contain_class('selinux').without_port }
-      it { is_expected.to contain_class('selinux').without_fcontext }
-      it { is_expected.to contain_class('selinux').without_permissive }
-      it { is_expected.to contain_class('selinux::package') }
-      it { is_expected.to contain_class('selinux::config') }
-      it { is_expected.to contain_class('selinux::params') }
-      it { is_expected.to contain_anchor('selinux::start').that_comes_before('Class[selinux::package]') }
-      it { is_expected.to contain_anchor('selinux::module pre').that_requires('Class[selinux::config]') }
-      it { is_expected.to contain_anchor('selinux::module pre').that_comes_before('Anchor[selinux::module post]') }
-      it { is_expected.to contain_anchor('selinux::module post').that_comes_before('Anchor[selinux::end]') }
-      it { is_expected.to contain_anchor('selinux::end').that_requires('Anchor[selinux::module post]') }
+      it { is_expected.to contain_class('vox_selinux').without_mode }
+      it { is_expected.to contain_class('vox_selinux').without_type }
+      it { is_expected.to contain_class('vox_selinux').without_module }
+      it { is_expected.to contain_class('vox_selinux').without_port }
+      it { is_expected.to contain_class('vox_selinux').without_fcontext }
+      it { is_expected.to contain_class('vox_selinux').without_permissive }
+      it { is_expected.to contain_class('vox_selinux::package') }
+      it { is_expected.to contain_class('vox_selinux::config') }
+      it { is_expected.to contain_class('vox_selinux::params') }
+      it { is_expected.to contain_anchor('vox_selinux::start').that_comes_before('Class[vox_selinux::package]') }
+      it { is_expected.to contain_anchor('vox_selinux::module pre').that_requires('Class[vox_selinux::config]') }
+      it { is_expected.to contain_anchor('vox_selinux::module pre').that_comes_before('Anchor[vox_selinux::module post]') }
+      it { is_expected.to contain_anchor('vox_selinux::module post').that_comes_before('Anchor[vox_selinux::end]') }
+      it { is_expected.to contain_anchor('vox_selinux::end').that_requires('Anchor[vox_selinux::module post]') }
 
       context 'with module resources defined' do
         let(:params) do
@@ -32,8 +32,8 @@ describe 'selinux' do
           }
         end
 
-        it { is_expected.to contain_selinux__module('mymodule1') }
-        it { is_expected.to contain_selinux__module('mymodule2') }
+        it { is_expected.to contain_vox_selinux__module('mymodule1') }
+        it { is_expected.to contain_vox_selinux__module('mymodule2') }
       end
 
       context 'with boolean resources defined' do
@@ -46,8 +46,8 @@ describe 'selinux' do
           }
         end
 
-        it { is_expected.to contain_selinux__boolean('mybool1') }
-        it { is_expected.to contain_selinux__boolean('mybool2') }
+        it { is_expected.to contain_vox_selinux__boolean('mybool1') }
+        it { is_expected.to contain_vox_selinux__boolean('mybool2') }
       end
 
       context 'with port resources defined' do
@@ -60,8 +60,8 @@ describe 'selinux' do
           }
         end
 
-        it { is_expected.to contain_selinux__port('myport1') }
-        it { is_expected.to contain_selinux__port('myport2') }
+        it { is_expected.to contain_vox_selinux__port('myport1') }
+        it { is_expected.to contain_vox_selinux__port('myport2') }
       end
 
       context 'with permissive resources defined' do
@@ -74,8 +74,8 @@ describe 'selinux' do
           }
         end
 
-        it { is_expected.to contain_selinux__permissive('domain1') }
-        it { is_expected.to contain_selinux__permissive('domain2') }
+        it { is_expected.to contain_vox_selinux__permissive('domain1') }
+        it { is_expected.to contain_vox_selinux__permissive('domain2') }
       end
 
       context 'with fcontext resources defined' do
@@ -89,9 +89,9 @@ describe 'selinux' do
           }
         end
 
-        it { is_expected.to contain_selinux__fcontext('myfcontext1') }
-        it { is_expected.to contain_selinux__fcontext('myfcontext2') }
-        it { is_expected.to contain_selinux__fcontext('/path/spec(.*)') }
+        it { is_expected.to contain_vox_selinux__fcontext('myfcontext1') }
+        it { is_expected.to contain_vox_selinux__fcontext('myfcontext2') }
+        it { is_expected.to contain_vox_selinux__fcontext('/path/spec(.*)') }
       end
     end
   end

--- a/spec/defines/selinux_boolean_spec.rb
+++ b/spec/defines/selinux_boolean_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'selinux::boolean' do
+describe 'vox_selinux::boolean' do
   let(:title) { 'mybool' }
 
   on_supported_os.each do |os, facts|
@@ -9,8 +9,8 @@ describe 'selinux::boolean' do
         facts
       end
 
-      it { is_expected.to contain_selinux__boolean('mybool').that_requires('Anchor[selinux::module post]') }
-      it { is_expected.to contain_selinux__boolean('mybool').that_comes_before('Anchor[selinux::end]') }
+      it { is_expected.to contain_vox_selinux__boolean('mybool').that_requires('Anchor[vox_selinux::module post]') }
+      it { is_expected.to contain_vox_selinux__boolean('mybool').that_comes_before('Anchor[vox_selinux::end]') }
 
       ['on', true, 'present'].each do |value|
         context value do

--- a/spec/defines/selinux_exec_restorecon_spec.rb
+++ b/spec/defines/selinux_exec_restorecon_spec.rb
@@ -1,38 +1,38 @@
 require 'spec_helper'
 
-describe 'selinux::exec_restorecon' do
+describe 'vox_selinux::exec_restorecon' do
   on_supported_os.each do |os, _facts|
     context "on #{os}" do
       context 'with resource titled /opt/mycustompath' do
         let(:title) { '/opt/mycustompath' }
 
         context 'with defaults' do
-          it { is_expected.to contain_exec('selinux::exec_restorecon /opt/mycustompath').with(command: 'restorecon -R /opt/mycustompath', refreshonly: true) }
+          it { is_expected.to contain_exec('vox_selinux::exec_restorecon /opt/mycustompath').with(command: 'restorecon -R /opt/mycustompath', refreshonly: true) }
         end
         context 'without recursion' do
           let(:params) { { recurse: false } }
 
-          it { is_expected.to contain_exec('selinux::exec_restorecon /opt/mycustompath').with(command: 'restorecon /opt/mycustompath') }
+          it { is_expected.to contain_exec('vox_selinux::exec_restorecon /opt/mycustompath').with(command: 'restorecon /opt/mycustompath') }
         end
         context 'with force' do
           let(:params) { { force: true } }
 
-          it { is_expected.to contain_exec('selinux::exec_restorecon /opt/mycustompath').with(command: 'restorecon -F -R /opt/mycustompath') }
+          it { is_expected.to contain_exec('vox_selinux::exec_restorecon /opt/mycustompath').with(command: 'restorecon -F -R /opt/mycustompath') }
         end
         context 'with force, without recursion' do
           let(:params) { { force: true, recurse: false } }
 
-          it { is_expected.to contain_exec('selinux::exec_restorecon /opt/mycustompath').with(command: 'restorecon -F /opt/mycustompath') }
+          it { is_expected.to contain_exec('vox_selinux::exec_restorecon /opt/mycustompath').with(command: 'restorecon -F /opt/mycustompath') }
         end
         context 'ordering' do
-          it { is_expected.to contain_exec('selinux::exec_restorecon /opt/mycustompath').that_comes_before('Anchor[selinux::end]') }
-          it { is_expected.to contain_anchor('selinux::module post').that_comes_before('Exec[selinux::exec_restorecon /opt/mycustompath]') }
+          it { is_expected.to contain_exec('vox_selinux::exec_restorecon /opt/mycustompath').that_comes_before('Anchor[vox_selinux::end]') }
+          it { is_expected.to contain_anchor('vox_selinux::module post').that_comes_before('Exec[vox_selinux::exec_restorecon /opt/mycustompath]') }
         end
         context 'with optional parameters' do
           let(:params) { { onlyif: 'some_command', unless: 'some_other_command', refreshonly: false } }
 
           it do
-            is_expected.to contain_exec('selinux::exec_restorecon /opt/mycustompath').with(
+            is_expected.to contain_exec('vox_selinux::exec_restorecon /opt/mycustompath').with(
               onlyif: 'some_command',
               unless: 'some_other_command',
               refreshonly: false
@@ -44,7 +44,7 @@ describe 'selinux::exec_restorecon' do
         let(:title) { '/opt/$HOME/some weird dir/' }
 
         context 'with defaults' do
-          it { is_expected.to contain_exec('selinux::exec_restorecon /opt/$HOME/some weird dir/').with(command: "restorecon -R '/opt/$HOME/some weird dir/'", refreshonly: true) }
+          it { is_expected.to contain_exec('vox_selinux::exec_restorecon /opt/$HOME/some weird dir/').with(command: "restorecon -R '/opt/$HOME/some weird dir/'", refreshonly: true) }
         end
       end
       context 'with path /weird/\'pa th\'/"quotes"' do
@@ -52,7 +52,7 @@ describe 'selinux::exec_restorecon' do
         let(:params) { { path: %q(/weird/'pa th'/"quotes") } }
 
         context 'with defaults' do
-          it { is_expected.to contain_exec(%q(selinux::exec_restorecon /weird/'pa th'/"quotes")).with(command: %q(restorecon -R "/weird/'pa th'/\"quotes\""), refreshonly: true) }
+          it { is_expected.to contain_exec(%q(vox_selinux::exec_restorecon /weird/'pa th'/"quotes")).with(command: %q(restorecon -R "/weird/'pa th'/\"quotes\""), refreshonly: true) }
         end
       end
     end

--- a/spec/defines/selinux_fcontext_equivalence_spec.rb
+++ b/spec/defines/selinux_fcontext_equivalence_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'selinux::fcontext::equivalence' do
+describe 'vox_selinux::fcontext::equivalence' do
   let(:title) { '/opt/some/path' }
 
   on_supported_os.each do |os, facts|
@@ -16,8 +16,8 @@ describe 'selinux::fcontext::equivalence' do
           }
         end
 
-        it { is_expected.to contain_selinux__fcontext__equivalence('/opt/some/path').that_requires('Anchor[selinux::module post]') }
-        it { is_expected.to contain_selinux__fcontext__equivalence('/opt/some/path').that_comes_before('Anchor[selinux::end]') }
+        it { is_expected.to contain_vox_selinux__fcontext__equivalence('/opt/some/path').that_requires('Anchor[vox_selinux::module post]') }
+        it { is_expected.to contain_vox_selinux__fcontext__equivalence('/opt/some/path').that_comes_before('Anchor[vox_selinux::end]') }
         it { is_expected.to contain_selinux_fcontext_equivalence('/opt/some/path').with(target: '/opt/some/other/path') }
       end
       context 'ordering on ensure => absent' do
@@ -28,8 +28,8 @@ describe 'selinux::fcontext::equivalence' do
           }
         end
 
-        it { is_expected.to contain_selinux__fcontext__equivalence('/opt/some/path').that_requires('Anchor[selinux::start]') }
-        it { is_expected.to contain_selinux__fcontext__equivalence('/opt/some/path').that_comes_before('Anchor[selinux::module pre]') }
+        it { is_expected.to contain_vox_selinux__fcontext__equivalence('/opt/some/path').that_requires('Anchor[vox_selinux::start]') }
+        it { is_expected.to contain_vox_selinux__fcontext__equivalence('/opt/some/path').that_comes_before('Anchor[vox_selinux::module pre]') }
         it { is_expected.to contain_selinux_fcontext_equivalence('/opt/some/path').with(ensure: 'absent', target: '/opt/some/other/path') }
       end
     end

--- a/spec/defines/selinux_fcontext_spec.rb
+++ b/spec/defines/selinux_fcontext_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'selinux::fcontext' do
+describe 'vox_selinux::fcontext' do
   let(:title) { 'myfile' }
 
   on_supported_os.each do |os, facts|
@@ -17,8 +17,8 @@ describe 'selinux::fcontext' do
           }
         end
 
-        it { is_expected.to contain_selinux__fcontext('myfile').that_requires('Anchor[selinux::module post]') }
-        it { is_expected.to contain_selinux__fcontext('myfile').that_comes_before('Anchor[selinux::end]') }
+        it { is_expected.to contain_vox_selinux__fcontext('myfile').that_requires('Anchor[vox_selinux::module post]') }
+        it { is_expected.to contain_vox_selinux__fcontext('myfile').that_comes_before('Anchor[vox_selinux::end]') }
       end
       context 'removal ordering' do
         let(:params) do
@@ -29,9 +29,9 @@ describe 'selinux::fcontext' do
           }
         end
 
-        it { is_expected.to contain_selinux__fcontext('myfile').that_requires('Anchor[selinux::start]') }
-        it { is_expected.to contain_selinux__fcontext('myfile').with(ensure: 'absent') }
-        it { is_expected.to contain_selinux__fcontext('myfile').that_comes_before('Anchor[selinux::module pre]') }
+        it { is_expected.to contain_vox_selinux__fcontext('myfile').that_requires('Anchor[vox_selinux::start]') }
+        it { is_expected.to contain_vox_selinux__fcontext('myfile').with(ensure: 'absent') }
+        it { is_expected.to contain_vox_selinux__fcontext('myfile').that_comes_before('Anchor[vox_selinux::module pre]') }
       end
 
       context 'invalid filetype' do

--- a/spec/defines/selinux_module_spec.rb
+++ b/spec/defines/selinux_module_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'selinux::module' do
+describe 'vox_selinux::module' do
   let(:title) { 'mymodule' }
 
   on_supported_os.each do |os, facts|
@@ -22,8 +22,8 @@ describe 'selinux::module' do
           }
         end
 
-        it { is_expected.to contain_selinux__module('mymodule').that_requires('Anchor[selinux::module pre]') }
-        it { is_expected.to contain_selinux__module('mymodule').that_comes_before('Anchor[selinux::module post]') }
+        it { is_expected.to contain_vox_selinux__module('mymodule').that_requires('Anchor[vox_selinux::module pre]') }
+        it { is_expected.to contain_vox_selinux__module('mymodule').that_comes_before('Anchor[vox_selinux::module post]') }
       end
 
       context 'present case with refpolicy builder and with te file only' do

--- a/spec/defines/selinux_permissive_spec.rb
+++ b/spec/defines/selinux_permissive_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'selinux::permissive' do
+describe 'vox_selinux::permissive' do
   let(:title) { 'mycontextp' }
 
   on_supported_os.each do |os, facts|
@@ -17,8 +17,8 @@ describe 'selinux::permissive' do
         end
 
         it { is_expected.to contain_selinux_permissive('oddjob_mkhomedir_t').with(ensure: 'present') }
-        it { is_expected.to contain_selinux__permissive('mycontextp').that_requires('Anchor[selinux::module post]') }
-        it { is_expected.to contain_selinux__permissive('mycontextp').that_comes_before('Anchor[selinux::end]') }
+        it { is_expected.to contain_vox_selinux__permissive('mycontextp').that_requires('Anchor[vox_selinux::module post]') }
+        it { is_expected.to contain_vox_selinux__permissive('mycontextp').that_comes_before('Anchor[vox_selinux::end]') }
       end
 
       context 'ensure selinux_permissive oddjob_mkhomedir_t is absent' do
@@ -30,8 +30,8 @@ describe 'selinux::permissive' do
         end
 
         it { is_expected.to contain_selinux_permissive('oddjob_mkhomedir_t').with(ensure: 'absent') }
-        it { is_expected.to contain_selinux__permissive('mycontextp').that_requires('Anchor[selinux::start]') }
-        it { is_expected.to contain_selinux__permissive('mycontextp').that_comes_before('Anchor[selinux::module pre]') }
+        it { is_expected.to contain_vox_selinux__permissive('mycontextp').that_requires('Anchor[vox_selinux::start]') }
+        it { is_expected.to contain_vox_selinux__permissive('mycontextp').that_comes_before('Anchor[vox_selinux::module pre]') }
       end
 
       context 'selinux_permissive oddjob_mkhomedir_t with title only' do
@@ -40,8 +40,8 @@ describe 'selinux::permissive' do
         end
 
         it { is_expected.to contain_selinux_permissive('oddjob_mkhomedir_t').with(ensure: 'present') }
-        it { is_expected.to contain_selinux__permissive('oddjob_mkhomedir_t').that_requires('Anchor[selinux::module post]') }
-        it { is_expected.to contain_selinux__permissive('oddjob_mkhomedir_t').that_comes_before('Anchor[selinux::end]') }
+        it { is_expected.to contain_vox_selinux__permissive('oddjob_mkhomedir_t').that_requires('Anchor[vox_selinux::module post]') }
+        it { is_expected.to contain_vox_selinux__permissive('oddjob_mkhomedir_t').that_comes_before('Anchor[vox_selinux::end]') }
       end
     end
   end

--- a/spec/defines/selinux_port_spec.rb
+++ b/spec/defines/selinux_port_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'selinux::port' do
+describe 'vox_selinux::port' do
   let(:title) { 'myapp' }
 
   on_supported_os.each do |os, facts|
@@ -18,8 +18,8 @@ describe 'selinux::port' do
           }
         end
 
-        it { is_expected.to contain_selinux__port('myapp').that_requires('Anchor[selinux::module post]') }
-        it { is_expected.to contain_selinux__port('myapp').that_comes_before('Anchor[selinux::end]') }
+        it { is_expected.to contain_vox_selinux__port('myapp').that_requires('Anchor[vox_selinux::module post]') }
+        it { is_expected.to contain_vox_selinux__port('myapp').that_comes_before('Anchor[vox_selinux::end]') }
       end
 
       %w[tcp udp].each do |protocol|


### PR DESCRIPTION
Re-namespaces the voxpupuli/selinux module in a way that is compatible
with the Apache 2.0 license.

SIMP-4712 #close
